### PR TITLE
Resolve small bug with document.querySelector on empty strings

### DIFF
--- a/src/min-css.js
+++ b/src/min-css.js
@@ -11,7 +11,7 @@ const getMinimalSelectors = async (page, selectors) => {
   return page.evaluate(selectors => {
     return selectors
       //.map(s => s.replace(/::.*/i, ''))   // ::before, etc
-      .filter(s => document.querySelector(s.replace(/::.*/i, '')));
+      .filter(s => s.replace(/::.*/i, '') && document.querySelector(s.replace(/::.*/i, '')));
   }, selectors);
 };
 


### PR DESCRIPTION
Hi @rakeshpai! Thanks so much for creating this library.

I was trying to use the library with my own project, and I noticed an issue where the `getMinimalSelectors` call may call `document.querySelector` on an empty string -- which causes puppeteer to crash.

I think this is a simple one line fix! Hope this helps, and please do let me know if you would prefer to make this change in a different way :)